### PR TITLE
Fix device_class for network metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.5.1
+
+* Fix device_class for home assistant for network metrics @pe-pe
+
 ## 1.5.0
 
 * Add home assistant option to disable attributes and only use entities

--- a/linux2mqtt/__init__.py
+++ b/linux2mqtt/__init__.py
@@ -1,6 +1,6 @@
 """linux2mqtt package."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 from .const import (
     DEFAULT_CONFIG,

--- a/linux2mqtt/metrics.py
+++ b/linux2mqtt/metrics.py
@@ -665,7 +665,7 @@ class NetworkMetrics(BaseMetric):
                     "state_field": f,
                     "icon": "mdi:server-network",
                     "unit_of_measurement": "kbit/s",
-                    "device_class": "data_size",
+                    "device_class": "data_rate",
                 }
             )
             for f in [


### PR DESCRIPTION
Hi, when using linux2mqtt with **homeassistant-disable-attributes** mode, the exported network metrics have invalid class (data_size). Unit of measurement is kbit/s, therefore class should be data_rate. 
This is the error visible in home assistant:

> Logger: homeassistant.components.mqtt.entity
> Source: components/mqtt/entity.py:156
> integration: MQTT ([documentation](https://www.home-assistant.io/integrations/mqtt), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+mqtt%22))
> First occurred: 1:22:38 PM (72 occurrences)
> Last logged: 3:09:56 PM
> Error 'The unit of measurement `kbit/s` is not valid together with device class `data_size`' when processing MQTT discovery message topic: 'homeassistant/sensor/linux/XXXXXXX_network_throughput__nic_eth0__total_rate/config'...

After correcting class, everything works fine in **homeassistant-disable-attributes** mode.

This pull request address the issue.