### PR TITLE
Optimize network metrics gathering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
     "mqtt",
     "mypy",
     "nics",
-    "numpy",
     "paho",
     "percpu",
     "pernic",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.6.0
+
+* Improve network statistics gathering while reducing cpu load @pe-pe
+
 ## 1.5.1
 
 * Fix device_class for home assistant for network metrics @pe-pe

--- a/linux2mqtt/__init__.py
+++ b/linux2mqtt/__init__.py
@@ -1,6 +1,6 @@
 """linux2mqtt package."""
 
-__version__ = "1.5.1"
+__version__ = "1.6.0b0"
 
 from .const import (
     DEFAULT_CONFIG,

--- a/linux2mqtt/__init__.py
+++ b/linux2mqtt/__init__.py
@@ -1,6 +1,6 @@
 """linux2mqtt package."""
 
-__version__ = "1.6.0b0"
+__version__ = "1.6.0"
 
 from .const import (
     DEFAULT_CONFIG,

--- a/linux2mqtt/metrics.py
+++ b/linux2mqtt/metrics.py
@@ -7,7 +7,6 @@ import time
 from typing import Any, Self
 
 import jsons
-import numpy as np
 import psutil
 from psutil._common import addr
 

--- a/linux2mqtt/metrics.py
+++ b/linux2mqtt/metrics.py
@@ -539,14 +539,14 @@ class NetworkMetricThread(BaseMetricThread):
         interval: int,
         nic: str,
     ):
-        """Initialize the cpu thread.
+        """Initialize the network thread.
 
         Parameters
         ----------
         result_queue: Queue[BaseMetric]
             The queue to put the metric into once the data is gathered
         metric
-            The cpu metric to gather data for
+            The network metric to gather data for
         interval
             The interval to gather data over
         nic
@@ -569,46 +569,45 @@ class NetworkMetricThread(BaseMetricThread):
 
         """
         try:
-            x = 0
-            interval = self.interval
-            tx_bytes = []
-            rx_bytes = []
-            prev_tx = 0
-            prev_rx = 0
-            base_tx = 0
-            base_rx = 0
-            while x < interval:
-                nics = psutil.net_io_counters(pernic=True)
-                if self.nic in nics:
-                    tx = nics[self.nic].bytes_sent
-                    rx = nics[self.nic].bytes_recv
-                    if tx < prev_tx:
-                        # TX counter rollover
-                        base_tx += prev_tx
-                    if rx < prev_rx:
-                        # RX counter rollover
-                        base_rx += prev_rx
-                    tx_bytes.append(base_tx + tx)
-                    rx_bytes.append(base_rx + rx)
-                    prev_tx = tx
-                    prev_rx = rx
-                time.sleep(1)
-                x += 1
-
+            start_tx = 0
+            start_rx = 0
+            # get initial counters
+            nics = psutil.net_io_counters(pernic=True)
             if self.nic in nics:
-                tx_rate_bytes_sec = np.average(np.diff(np.array(tx_bytes)))
-                tx_rate = tx_rate_bytes_sec / 125.0  # bytes/sec to kilobits/sec
-                rx_rate_bytes_sec = np.average(np.diff(np.array(rx_bytes)))
-                rx_rate = rx_rate_bytes_sec / 125.0  # bytes/sec to kilobits/sec
-
-                self.metric.polled_result = {
-                    "total_rate": int(tx_rate + rx_rate),
-                    "tx_rate": int(tx_rate),
-                    "rx_rate": int(rx_rate),
-                }
-                self.result_queue.put(self.metric)
+                start_tx = nics[self.nic].bytes_sent
+                start_rx = nics[self.nic].bytes_recv
             else:
                 metric_logger.warning("Network %s not available", self.nic)
+            time.sleep(self.interval)
+            # get counters after interval
+            nics = psutil.net_io_counters(pernic=True)
+            if self.nic in nics:
+                end_tx = nics[self.nic].bytes_sent
+                end_rx = nics[self.nic].bytes_recv
+            else:
+                metric_logger.warning("Network %s not available", self.nic)
+                # If the NIC is not available at the end, assume no change
+                end_tx = start_tx
+                end_rx = start_rx
+            # handle counter rollover by ignoring bytes from start_tx/start_rx to maxvalue
+            if end_tx >= start_tx:
+                diff_tx = end_tx - start_tx
+            else:
+                diff_tx = end_tx
+            if end_rx >= start_rx:
+                diff_rx = end_rx - start_rx
+            else:
+                diff_rx = end_rx
+            # calculate rate bytes/sec and convert bytes to kilobits/sec
+            tx_rate = diff_tx / self.interval / 125.0
+            rx_rate = diff_rx / self.interval / 125.0
+
+            self.metric.polled_result = {
+                "total_rate": int(tx_rate + rx_rate),
+                "tx_rate": int(tx_rate),
+                "rx_rate": int(rx_rate),
+            }
+            self.result_queue.put(self.metric)
         except Exception as ex:
             raise Linux2MqttMetricsException(
                 "Could not gather and publish network data"

--- a/linux2mqtt/metrics.py
+++ b/linux2mqtt/metrics.py
@@ -577,6 +577,7 @@ class NetworkMetricThread(BaseMetricThread):
                 start_rx = nics[self.nic].bytes_recv
             else:
                 metric_logger.warning("Network %s not available", self.nic)
+                return
             time.sleep(self.interval)
             # get counters after interval
             nics = psutil.net_io_counters(pernic=True)
@@ -585,9 +586,7 @@ class NetworkMetricThread(BaseMetricThread):
                 end_rx = nics[self.nic].bytes_recv
             else:
                 metric_logger.warning("Network %s not available", self.nic)
-                # If the NIC is not available at the end, assume no change
-                end_tx = start_tx
-                end_rx = start_rx
+                return
             # handle counter rollover by ignoring bytes from start_tx/start_rx to maxvalue
             if end_tx >= start_tx:
                 diff_tx = end_tx - start_tx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "jsons",
   "psutil",
   "paho-mqtt",
-  "numpy",
   "typing-extensions"
 ]
 requires-python = ">=3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 paho-mqtt
 jsons
 psutil
-numpy
 typing-extensions

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,6 @@ types-paho-mqtt
 jsons
 psutil
 types-psutil
-numpy
 typing-extensions
 mypy
 pydantic


### PR DESCRIPTION
Hi. I've been using linux2mqtt for a while and I have noticed, that sometimes it reports very strange numbers for my network statistics (way to large throughput).
It seems existing code was taking network statistics measurement every second and then approximating and reporting them every "interval" period.
Since network counters are generally growing, I proposed more simple and less CPU intensive approach:

1. Capture start metrics at point-in-time
2. Wait "interval" seconds
3. Capture end (final) metrics
4. Calculate difference (simple handle of overflow scenario)

Such approach reduces CPU load (no more data gathering every second) and simplifies the logic (no approximation across measurements is needed, which I expect was the reason for "odd" numbers).
