### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,6 +2,8 @@ name: Markdownlint
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,4 +1,6 @@
 name: Mypy
+permissions:
+  contents: read
 
 on: [ push, pull_request ]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   build:
     name: Build distribution 📦
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,6 +4,8 @@ on: [ push, pull_request ]
 
 jobs:
   ruff:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/linux2mqtt/security/code-scanning/12](https://github.com/miaucl/linux2mqtt/security/code-scanning/12)

To fix the problem, we need to explicitly set the permissions for the `GITHUB_TOKEN` used by the workflow. The best way to do this is to add a `permissions:` block to the root of the workflow YAML file (.github/workflows/mypy.yaml), just after the `name:` and before defining jobs. Since the job only checks out the repository and installs dependencies, it only needs read-only access to the repository contents. Therefore, we should set the minimal set of permissions: `contents: read`. No other changes, imports, or steps are required elsewhere in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
