### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,8 @@ jobs:
   check_version:
     name: Check the version
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    permissions:
+      contents: read
     needs:
       - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/linux2mqtt/security/code-scanning/5](https://github.com/miaucl/linux2mqtt/security/code-scanning/5)

To fix this issue, set explicit minimal permissions for the `check_version` job to restrict GITHUB_TOKEN access. Since the job only reads repository contents (code, changelogs, etc), the minimal required permission is `contents: read`. Insert a `permissions:` block directly under the `check_version:` job, specifying `contents: read`. No changes to other jobs or workflow functionality are needed.

Edit .github/workflows/publish.yml by adding:
```yaml
permissions:
  contents: read
```
underneath
```yaml
35: name: Check the version
36: if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
```
in the `check_version` job definition.

No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
